### PR TITLE
add xmlmind whc compiler to provide html5 web help

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ttf-dejavu \
     fonts-ipafont \
     fonts-wqy-microhei \
+    wget \
     && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://www.xmlmind.com/ditac/_whc/whc-3_1_1.zip -O /tmp/whc.zip\
+&& unzip /tmp/whc.zip -d /opt
 
 WORKDIR /work/root/doc_src
 

--- a/doc_src_paths.xml
+++ b/doc_src_paths.xml
@@ -5,4 +5,5 @@
     <property name="fop.home.build" value="/usr/share/java" />
     <property name="dbk" value="/usr/share/xml/docbook/stylesheet/docbook-xsl" />
     <property name="saxon" value="/usr/share/java/saxon.jar" />
+    <property name="whc" value="/opt/whc-3_1_1/lib/whc.jar" />
 </project>


### PR DESCRIPTION
Hi, this this my first contribution to OmegaT webhelp. It adds the web help compiler to the docker image (in /opt)
web help compiler is a java package from xmlmind, which is released under the MIT / Gnu GPL v2 licence.
